### PR TITLE
[R4R] store nft info when withdrawing nfts from l1

### DIFF
--- a/contracts/dev-contract/OldZkbas.sol
+++ b/contracts/dev-contract/OldZkbas.sol
@@ -325,7 +325,7 @@ contract OldZkbas is UpgradeableMaster, Events, Storage, Config, ReentrancyGuard
     }
 
     function withdrawOrStoreNFT(TxTypes.WithdrawNft memory op) internal {
-        require(op.nftIndex != 2**40-1, "invalid nft index");
+        require(op.nftIndex < 2**40-1, "invalid nft index");
 
         // get layer-1 address by account name hash
         bytes memory _emptyExtraData;


### PR DESCRIPTION
### Description

When depositing nft from l1, `collectionId`, `nftIndex`, `creatorAccountIndex` will be initiated by the max value, so it would be easy to distinguish the new nfts.

This pr will also store the nft info of the l1 nfts when withdrawing, so when the nfts are deposited into l2 again, they will not be viewed as new nfts.


### Changes

Notable changes:
* change the initial value of `collectionId`, `nftIndex` and `creatorAccountIndex` 
* store nft info of l1 nfts