### PR TITLE
add field in DepositNft tx to mark whether the deposited nft is a new nft or not

### DIFF
--- a/contracts/TxTypes.sol
+++ b/contracts/TxTypes.sol
@@ -259,6 +259,7 @@ library TxTypes {
 
     struct DepositNft {
         uint8 txType;
+        uint8 isNewNft;
         uint32 accountIndex;
         uint40 nftIndex;
         address nftL1Address;
@@ -274,18 +275,35 @@ library TxTypes {
 
     /// Serialize deposit pubdata
     function writeDepositNftPubDataForPriorityQueue(DepositNft memory _tx) internal pure returns (bytes memory buf) {
-        buf = abi.encodePacked(
-            uint8(TxType.DepositNft),
-            uint32(_tx.accountIndex),
-            uint40(_tx.nftIndex),
-            _tx.nftL1Address, // token address
-            _tx.creatorAccountIndex,
-            _tx.creatorTreasuryRate,
-            _tx.nftContentHash,
-            _tx.nftL1TokenId, // nft token id
-            _tx.accountNameHash,
-            _tx.collectionId// account name hash
-        );
+        if (_tx.isNewNft == 1) {
+            buf = abi.encodePacked(
+                uint8(TxType.DepositNft),
+                _tx.isNewNft,
+                0,
+                0,
+                _tx.nftL1Address, // token address
+                _tx.creatorAccountIndex,
+                _tx.creatorTreasuryRate,
+                _tx.nftContentHash,
+                _tx.nftL1TokenId, // nft token id
+                _tx.accountNameHash,
+                _tx.collectionId// account name hash
+            );
+        } else {
+            buf = abi.encodePacked(
+                uint8(TxType.DepositNft),
+                _tx.isNewNft,
+                0,
+                uint40(_tx.nftIndex),
+                _tx.nftL1Address, // token address
+                _tx.creatorAccountIndex,
+                _tx.creatorTreasuryRate,
+                _tx.nftContentHash,
+                _tx.nftL1TokenId, // nft token id
+                _tx.accountNameHash,
+                _tx.collectionId// account name hash
+            );
+        }
     }
 
     /// Deserialize deposit pubdata
@@ -293,13 +311,15 @@ library TxTypes {
         // NOTE: there is no check that variable sizes are same as constants (i.e. TOKEN_BYTES), fix if possible.
         uint256 offset = TX_TYPE_BYTES;
         // account index
+        (offset, parsed.isNewNft) = Bytes.readUInt8(_data, offset);
+        // account index
         (offset, parsed.accountIndex) = Bytes.readUInt32(_data, offset);
         // nft index
         (offset, parsed.nftIndex) = Bytes.readUInt40(_data, offset);
         // nft l1 address
         (offset, parsed.nftL1Address) = Bytes.readAddress(_data, offset);
         // empty data
-        offset += 26;
+        offset += 25;
         // creator account index
         (offset, parsed.creatorAccountIndex) = Bytes.readUInt32(_data, offset);
         // creator treasury rate

--- a/contracts/TxTypes.sol
+++ b/contracts/TxTypes.sol
@@ -279,8 +279,8 @@ library TxTypes {
             buf = abi.encodePacked(
                 uint8(TxType.DepositNft),
                 _tx.isNewNft,
-                0,
-                0,
+                uint32(0),
+                uint40(0),
                 _tx.nftL1Address, // token address
                 _tx.creatorAccountIndex,
                 _tx.creatorTreasuryRate,
@@ -293,7 +293,7 @@ library TxTypes {
             buf = abi.encodePacked(
                 uint8(TxType.DepositNft),
                 _tx.isNewNft,
-                0,
+                uint32(0),
                 uint40(_tx.nftIndex),
                 _tx.nftL1Address, // token address
                 _tx.creatorAccountIndex,

--- a/contracts/TxTypes.sol
+++ b/contracts/TxTypes.sol
@@ -276,8 +276,8 @@ library TxTypes {
     function writeDepositNftPubDataForPriorityQueue(DepositNft memory _tx) internal pure returns (bytes memory buf) {
         buf = abi.encodePacked(
             uint8(TxType.DepositNft),
-            uint32(0),
-            uint40(0),
+            uint32(_tx.accountIndex),
+            uint40(_tx.nftIndex),
             _tx.nftL1Address, // token address
             _tx.creatorAccountIndex,
             _tx.creatorTreasuryRate,

--- a/contracts/dev-contract/OldZkbas.sol
+++ b/contracts/dev-contract/OldZkbas.sol
@@ -285,9 +285,9 @@ contract OldZkbas is UpgradeableMaster, Events, Storage, Config, ReentrancyGuard
 
         // check if the nft is mint from layer-2
         bytes32 nftKey = keccak256(abi.encode(_nftL1Address, _nftL1TokenId));
-        uint16 collectionId = 0;
-        uint40 nftIndex = 0;
-        uint32 creatorAccountIndex = 0;
+        uint16 collectionId = 2**16-1;
+        uint40 nftIndex = 2**40-1;
+        uint32 creatorAccountIndex = 2**32-1;
         uint16 creatorTreasuryRate = 0;
         bytes32 nftContentHash;
         uint8 isNewNft = 1;

--- a/contracts/dev-contract/OldZkbas.sol
+++ b/contracts/dev-contract/OldZkbas.sol
@@ -285,16 +285,19 @@ contract OldZkbas is UpgradeableMaster, Events, Storage, Config, ReentrancyGuard
 
         // check if the nft is mint from layer-2
         bytes32 nftKey = keccak256(abi.encode(_nftL1Address, _nftL1TokenId));
-        uint16 collectionId = 2**16-1;
-        uint40 nftIndex = 2**40-1;
-        uint32 creatorAccountIndex = 2**32-1;
+        uint16 collectionId = 0;
+        uint40 nftIndex = 0;
+        uint32 creatorAccountIndex = 0;
         uint16 creatorTreasuryRate = 0;
         bytes32 nftContentHash;
+        uint8 isNewNft = 1;
         if (l2Nfts[nftKey].nftContentHash == bytes32(0)) {
             // it means this is a new layer-1 nft
             nftContentHash = nftKey;
         } else {
             // it means this is a nft that comes from layer-2
+            isNewNft = 0;
+
             nftContentHash = l2Nfts[nftKey].nftContentHash;
             collectionId = l2Nfts[nftKey].collectionId;
             nftIndex = l2Nfts[nftKey].nftIndex;
@@ -304,6 +307,7 @@ contract OldZkbas is UpgradeableMaster, Events, Storage, Config, ReentrancyGuard
 
         TxTypes.DepositNft memory _tx = TxTypes.DepositNft({
             txType : uint8(TxTypes.TxType.DepositNft),
+            isNewNft: isNewNft,
             accountIndex : 0, // unknown at this point
             nftIndex : nftIndex,
             nftL1Address : _nftL1Address,
@@ -751,9 +755,9 @@ contract OldZkbas is UpgradeableMaster, Events, Storage, Config, ReentrancyGuard
         bytes20 hashedPubData = Utils.hashBytesToBytes20(_pubData);
 
         priorityRequests[nextPriorityRequestId] = PriorityTx({
-        hashedPubData : hashedPubData,
-        expirationBlock : expirationBlock,
-        txType : _txType
+            hashedPubData : hashedPubData,
+            expirationBlock : expirationBlock,
+            txType : _txType
         });
 
         emit NewPriorityRequest(msg.sender, nextPriorityRequestId, _txType, _pubData, uint256(expirationBlock));


### PR DESCRIPTION
### Description

This pr will add a field `isNewNft` in `DepositNft` to mark whether the deposited nft is a new nft or not.

### Changes

Notable changes:
*  add new field `isNewNft`
